### PR TITLE
[FIX] safari 스크롤 바운싱 문제 & 카드 겹침 현상 제거

### DIFF
--- a/src/main/resources/templates/restaurant/list.html
+++ b/src/main/resources/templates/restaurant/list.html
@@ -30,7 +30,6 @@
             flex-direction: column;
             transition: transform 0.2s;
             cursor: pointer;
-            width: calc(130%);
             margin-left: -15%;
             margin-right: -15%;
         }
@@ -102,6 +101,11 @@
         }
 
         @media (max-width: 767px) {
+            html, body {
+                width: 100%;
+                overflow-x: hidden;
+            }
+
             .pc-only.card-container {
                 display: none;
             }
@@ -127,7 +131,13 @@
             .card {
                 flex: 0 0 calc(33.33% - 20px);
                 scroll-snap-align: start;
-                margin-right: 20px;
+                height: 390px;
+                margin-left: 5px;
+                margin-right: 5px;
+                margin-top: 10px;
+            }
+            .card-column {
+                margin: 0px;
             }
             .card:last-child {
                 margin-right: 0;
@@ -289,9 +299,15 @@
                                     <h5 class="card-title restaurant-name mb-0" th:classappend="${#strings.length(restaurant.name) > 10} ? 'long'" th:text="${restaurant.name}">맛집 이름</h5>
                                     <span class="card-subtitle text-body-secondary" th:text="${restaurant.getMenu().get(0)}"></span>
                                     <p class="card-text">
-                                        <span th:each="category, iterStat : ${restaurant.getCategories()}"
-                                              class="category-item"
-                                              th:text="${category.name}"></span>
+                                        <th:block th:if="${#lists.size(restaurant.getCategories()) > 2}">
+                                            <span class="category-item" th:text="${restaurant.getCategories()[0].name}"></span>
+                                            <span class="category-item">...</span>
+                                        </th:block>
+                                        <th:block th:if="${#lists.size(restaurant.getCategories()) <= 2}">
+                                    <span th:each="category, iterStat : ${restaurant.getCategories()}"
+                                          class="category-item"
+                                          th:text="${category.name}"></span>
+                                        </th:block>
                                     </p>
                                     <div class="d-flex justify-content-end flex-column">
                                         <div class="rating mb-2">


### PR DESCRIPTION
# 사파리 브라우저에서 발생하던 스크롤 바운싱 문제 해결
원인: body 및 html 즉 최상위 태그의 좌우 사이즈가 device의 화면보다 커서 좌우로 스크롤이 가능해짐 -> safari 기본 기능인 스크롤 바운싱으로 인한 어지러운 화면전환 발생

# 리스트페이지 카드겹침현상 해결
원인: 카드의 사이즈가 너무크고, 커지는 에니메이션을 고려하지 않은 여백 -> 여백과 크기 조정으로 수정